### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Paol0B/Argon2Sharp/security/code-scanning/1](https://github.com/Paol0B/Argon2Sharp/security/code-scanning/1)

The best way to fix the problem is to explicitly add a `permissions` block to the workflow to limit the GITHUB_TOKEN permissions. In this case, since most jobs only need to read the repository contents, and only the PR comment step requires limited write access (`pull-requests: write`), adding `permissions` at the workflow root (before `jobs:`) with `contents: read` as a minimum is advisable. If finer granularity per-job or per-step is required, you can override in those jobs (or steps), but a root block with `contents: read` sufficiently mitigates the issue raised by CodeQL.

To do this, edit `.github/workflows/dotnet.yml`:
- Insert the permissions block after the workflow `name:` and before the `on:` key.
- Use `contents: read` as a minimal starting point.
- If future edits are needed for more privilege (for specific jobs or steps), you can override in those jobs.

No new imports or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
